### PR TITLE
Added better response for organisations

### DIFF
--- a/src/main/java/org/mongen/core/controller/BeneficiaryController.java
+++ b/src/main/java/org/mongen/core/controller/BeneficiaryController.java
@@ -3,6 +3,7 @@ package org.mongen.core.controller;
 import java.util.List;
 
 import org.mongen.core.models.Beneficiary;
+import org.mongen.core.models.payloads.BeneficiaryPayload;
 import org.mongen.core.service.BeneficiaryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -40,7 +41,7 @@ public class BeneficiaryController {
 	
 	@ApiOperation(value = "Create a Beneficiary")
 	@PostMapping("/beneficiaries")
-	public ResponseEntity<Beneficiary> createBeneficiary(@RequestBody Beneficiary beneficiary){
+	public ResponseEntity<Beneficiary> createBeneficiary(@RequestBody BeneficiaryPayload beneficiary){
 		Beneficiary bene = beneficiaryServ.createBeneficiary(beneficiary);
 		return ResponseEntity.status(HttpStatus.CREATED).body(bene);
 	}

--- a/src/main/java/org/mongen/core/controller/OrganizationController.java
+++ b/src/main/java/org/mongen/core/controller/OrganizationController.java
@@ -3,6 +3,7 @@ package org.mongen.core.controller;
 import io.swagger.annotations.ApiOperation;
 import org.mongen.core.models.Organization;
 import org.mongen.core.models.payloads.OrganizationPayload;
+import org.mongen.core.models.responses.OrganizationResponse;
 import org.mongen.core.service.OrganizationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -26,9 +27,18 @@ public class OrganizationController {
 	
 	@ApiOperation(value = "Get one Organization")
 	@GetMapping("/organization/{id}")
-	public ResponseEntity<Organization> getOrganizationId(@PathVariable("id") Long id){
-		Organization bene = organizationServ.findOrganizationById(id);
-		return ResponseEntity.status(HttpStatus.OK).body(bene);
+	public ResponseEntity<OrganizationResponse> getOrganizationId(@PathVariable("id") Long id){
+		Organization org = organizationServ.findOrganizationById(id);
+		OrganizationResponse org_resp = organizationServ.generateOrganizationResponse(org);
+		return ResponseEntity.status(HttpStatus.OK).body(org_resp);
+	}
+
+	@ApiOperation(value = "Get one Organization by SEO name")
+	@GetMapping("/organization/seo_name/{seo_name}")
+	public ResponseEntity<OrganizationResponse> getOrganizationSeoName(@PathVariable("seo_name") String seo_name){
+		Organization org = organizationServ.findOrganizationBySeoName(seo_name);
+		OrganizationResponse org_resp = organizationServ.generateOrganizationResponse(org);
+		return ResponseEntity.status(HttpStatus.OK).body(org_resp);
 	}
 	
 	@ApiOperation(value = "Create a Organization")

--- a/src/main/java/org/mongen/core/models/Beneficiary.java
+++ b/src/main/java/org/mongen/core/models/Beneficiary.java
@@ -37,7 +37,7 @@ public class Beneficiary implements Serializable{
 	private String gender;
 	private Integer age;
 	@Column(name="date_of_birth")
-	private Date birth;
+	private Date dateOfBirth;
 	private Integer height;
 	private Integer weight;
 	private String address;
@@ -86,6 +86,31 @@ public class Beneficiary implements Serializable{
 
 	public Beneficiary() {
 
+	}
+
+	public Beneficiary(
+			String first_name,
+			String last_name,
+			String gender,
+			Date date_of_birth,
+			Integer height,
+			Integer weight,
+			String address,
+//			Integer[] disability_ids,
+//			Integer street_situation_id,
+		    Country country
+	) {
+
+		this.firstName = first_name;
+		this.lastName = last_name;
+		this.gender = gender;
+		this.dateOfBirth = date_of_birth;
+		this.height = height;
+		this.weight = weight;
+		this.address = address;
+		this.country = country;
+//		this.street_situation = street_situation_id;
+//		this.disabilities = disability_ids;
 	}
 	
 	@PrePersist

--- a/src/main/java/org/mongen/core/models/Organization.java
+++ b/src/main/java/org/mongen/core/models/Organization.java
@@ -19,7 +19,7 @@ public class Organization implements Serializable{
 	@Column(name="name")
 	private String name;
 	@Column(name="seo_name")
-	private String SeoName;
+	private String seoName;
 	private boolean verified;
 	private String address;
 	private String mission;
@@ -54,7 +54,7 @@ public class Organization implements Serializable{
 
 	public Organization(String name, String seo_name, String mission, String vision, String address, Country country, Collaborator contact) {
 		this.name = name;
-		this.SeoName = seo_name;
+		this.seoName = seo_name;
 		this.mission = mission;
 		this.vision = vision;
 		this.address = address;

--- a/src/main/java/org/mongen/core/models/Organization.java
+++ b/src/main/java/org/mongen/core/models/Organization.java
@@ -46,7 +46,15 @@ public class Organization implements Serializable{
 			joinColumns = @JoinColumn(name = "organization_id"),
 			inverseJoinColumns = @JoinColumn(name = "collaborator_id")
 	)
-	private List<Beneficiary> collaborators;
+	private List<Collaborator> collaborators;
+
+	@ManyToMany
+	@JoinTable(
+			name = "organization_beneficiaries",
+			joinColumns = @JoinColumn(name = "organization_id"),
+			inverseJoinColumns = @JoinColumn(name = "beneficiary_id")
+	)
+	private List<Beneficiary> beneficiaries;
 
 	public Organization() {
 		

--- a/src/main/java/org/mongen/core/models/payloads/BeneficiaryPayload.java
+++ b/src/main/java/org/mongen/core/models/payloads/BeneficiaryPayload.java
@@ -1,0 +1,20 @@
+package org.mongen.core.models.payloads;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class BeneficiaryPayload {
+	String first_name;
+	String last_name;
+	String gender;
+	Date date_of_birth;
+	Integer height;
+	Integer weight;
+	String address;
+//	Integer[] disability_ids;
+	String country_iso;
+//	Integer street_situation_id;
+//	Integer organization_id;
+}

--- a/src/main/java/org/mongen/core/models/responses/OrganizationResponse.java
+++ b/src/main/java/org/mongen/core/models/responses/OrganizationResponse.java
@@ -1,0 +1,37 @@
+package org.mongen.core.models.responses;
+
+import lombok.Data;
+import org.mongen.core.models.Collaborator;
+import org.mongen.core.models.Organization;
+
+import java.util.Date;
+
+@Data
+public class OrganizationResponse {
+
+	private Long id;
+	private String name;
+	private String seo_name;
+	private String address;
+	private String mission;
+	private String vision;
+	private Collaborator main_contact;
+	private boolean verified;
+	private Date created;
+	private Date updated;
+	private String country;
+
+	public OrganizationResponse(Organization org){
+		this.id = org.getId();
+		this.name = org.getName();
+		this.seo_name = org.getSeoName();
+		this.address = org.getAddress();
+		this.mission = org.getMission();
+		this.vision = org.getVision();
+		this.main_contact = org.getCollaborator();
+		this.verified = org.isVerified();
+		this.created = org.getCreated();
+		this.updated = org.getUpdated();
+		this.country = org.getCountry().getName();
+	}
+}

--- a/src/main/java/org/mongen/core/repository/OrganizationRepository.java
+++ b/src/main/java/org/mongen/core/repository/OrganizationRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface OrganizationRepository extends CrudRepository<Organization,Long>{
 	List<Organization> findAll();
+
+	Organization findBySeoName(String SeoName);
 }

--- a/src/main/java/org/mongen/core/service/BeneficiaryService.java
+++ b/src/main/java/org/mongen/core/service/BeneficiaryService.java
@@ -1,10 +1,14 @@
 package org.mongen.core.service;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
 import org.mongen.core.models.Beneficiary;
+import org.mongen.core.models.Country;
+import org.mongen.core.models.payloads.BeneficiaryPayload;
 import org.mongen.core.repository.BeneficiaryRepository;
+import org.mongen.core.repository.CountryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +16,8 @@ import org.springframework.stereotype.Service;
 public class BeneficiaryService {
 	@Autowired
 	BeneficiaryRepository beneficiaryRepo;
+	@Autowired
+	CountryRepository countryRepo;
 	
 	public List<Beneficiary> getBeneficiaries(){
 		return beneficiaryRepo.findAll();
@@ -26,8 +32,21 @@ public class BeneficiaryService {
 		}
 	}
 	
-	public Beneficiary createBeneficiary(Beneficiary nuevo) {
-		return beneficiaryRepo.save(nuevo);
+	public Beneficiary createBeneficiary(BeneficiaryPayload new_beneficiary) {
+		Country country = countryRepo.findByCountryISO(new_beneficiary.getCountry_iso());
+		// TODO: Process disabilities, street situations and organization
+		Beneficiary beneficiary = new Beneficiary(
+				new_beneficiary.getFirst_name(),
+				new_beneficiary.getLast_name(),
+				new_beneficiary.getGender(),
+				new_beneficiary.getDate_of_birth(),
+				new_beneficiary.getHeight(),
+				new_beneficiary.getWeight(),
+				new_beneficiary.getAddress(),
+				country
+		);
+
+		return beneficiaryRepo.save(beneficiary);
 	}
 	
 	public Beneficiary updateBeneficiary(Beneficiary nuevo,Long id) {

--- a/src/main/java/org/mongen/core/service/OrganizationService.java
+++ b/src/main/java/org/mongen/core/service/OrganizationService.java
@@ -5,6 +5,7 @@ import org.mongen.core.models.CollaboratorType;
 import org.mongen.core.models.Country;
 import org.mongen.core.models.Organization;
 import org.mongen.core.models.payloads.OrganizationPayload;
+import org.mongen.core.models.responses.OrganizationResponse;
 import org.mongen.core.repository.CollaboratorRepository;
 import org.mongen.core.repository.CountryRepository;
 import org.mongen.core.repository.OrganizationRepository;
@@ -35,6 +36,15 @@ public class OrganizationService {
 			return null;
 		}
 	}
+
+	public Organization findOrganizationBySeoName(String seo_name) {
+		Optional<Organization> temp = Optional.ofNullable(organizationRepo.findBySeoName(seo_name));
+		if(temp.isPresent()) {
+			return temp.get();
+		} else {
+			return null;
+		}
+	}
 	
 	public Organization createOrganization(OrganizationPayload org_payload) {
 		Country country = countryRepo.findByCountryISO(org_payload.getCountry_iso());
@@ -46,6 +56,11 @@ public class OrganizationService {
 	public Organization updateOrganization(Organization nuevo, Long id) {
 		nuevo.setId(id);
 		return organizationRepo.save(nuevo);
+	}
+
+	public OrganizationResponse generateOrganizationResponse(Organization org){
+		OrganizationResponse org_resp = new OrganizationResponse(org);
+		return org_resp;
 	}
 	
 	public void deleteOrganization(Long id) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port=8080
-spring.datasource.url=jdbc:postgresql://db:5432/mongen_db
+spring.datasource.url=jdbc:postgresql://localhost:5432/mongen_db
 spring.datasource.username=mongen
 spring.datasource.password=123123
 spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port=8080
-spring.datasource.url=jdbc:postgresql://localhost:5432/mongen_db
+spring.datasource.url=jdbc:postgresql://db:5432/mongen_db
 spring.datasource.username=mongen
 spring.datasource.password=123123
 spring.jpa.show-sql=true


### PR DESCRIPTION
Added new endpoint `/api/v1/organization/seo_name/{seo_name}`

Also, this endpoint, and `/api/v1/organization/{id}` will return this new response:

```
{
  "id": 0,
  "name": "",
  "seo_name": "",
  "address": "",
  "mission": "",
  "vision": "",
  "main_contact": {
    "id": 8,
    "firstName": "",
    "lastName": "",
    "photoIdURL": "",
    "countryCollaborator": {
      "countryISO": "",
      "countryISO3": "",
      "callingCode": "",
      "name": ""
    },
    "type": {
      "id": 1,
      "name": ""
    }
  },
  "verified": false,
  "created": "",
  "updated": null,
  "country": ""
}
```

Refactored payload to create a beneficiary `/api/v1/beneficiaries`
(Is still missing data like disabilities, street situation, and organization related)

```
{
  "address": "string",
  "country_iso": "string",
  "date_of_birth": "",
  "first_name": "string",
  "gender": "string",
  "height": 0,
  "last_name": "string",
  "weight": 0
}
```
