### PR TITLE
Added story and email, collaborator response refactored

### DIFF
--- a/src/main/java/org/mongen/core/controller/CollaboratorController.java
+++ b/src/main/java/org/mongen/core/controller/CollaboratorController.java
@@ -6,6 +6,8 @@ import org.mongen.core.models.Collaborator;
 import org.mongen.core.models.CollaboratorType;
 import org.mongen.core.models.payloads.CollaboratorPayload;
 import org.mongen.core.models.payloads.MainContactPayload;
+import org.mongen.core.models.responses.CollaboratorResponse;
+import org.mongen.core.models.responses.MainContactResponse;
 import org.mongen.core.service.CollaboratorService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -43,14 +45,21 @@ public class CollaboratorController {
 	}
 	
 	@ApiOperation(value = "Get one Collaborator")
-	@GetMapping("/collaborators/{id}")
-	public ResponseEntity<Collaborator> getCollaboratorId(@PathVariable("id") Long id){
-		Collaborator cola = collaboratorServ.findCollaboratorById(id);
+	@GetMapping("/collaborator/{id}")
+	public ResponseEntity<CollaboratorResponse> getCollaboratorId(@PathVariable("id") Long id){
+		CollaboratorResponse cola = new CollaboratorResponse(collaboratorServ.findCollaboratorById(id));
+		return ResponseEntity.status(HttpStatus.OK).body(cola);
+	}
+
+	@ApiOperation(value = "Get one Main Contact")
+	@GetMapping("/main_contact/{id}")
+	public ResponseEntity<MainContactResponse> getMainContactId(@PathVariable("id") Long id){
+		MainContactResponse cola = new MainContactResponse(collaboratorServ.findCollaboratorById(id));
 		return ResponseEntity.status(HttpStatus.OK).body(cola);
 	}
 	
 	@ApiOperation(value = "Create a Collaborator")
-	@PostMapping("/collaborators")
+	@PostMapping("/collaborator")
 	public ResponseEntity<Collaborator> createCollaborator(@RequestBody CollaboratorPayload collaborator){
 		Collaborator new_collaborator = collaboratorServ.createCollaborator(collaborator);
 		return ResponseEntity.status(HttpStatus.CREATED).body(new_collaborator);
@@ -64,14 +73,14 @@ public class CollaboratorController {
 	}
 	
 	@ApiOperation(value = "Update a Collaborator")
-	@PatchMapping("/collaborators/{id}")
+	@PatchMapping("/collaborator/{id}")
 	public ResponseEntity<Collaborator> updateCollaborator(@PathVariable("id") Long id, @RequestBody Collaborator collaborator){
 		Collaborator cola = collaboratorServ.updateCollaborator(collaborator, id);
 		return ResponseEntity.status(HttpStatus.OK).body(cola);
 	}
 	
 	@ApiOperation(value = "Delete a Collaborator")
-	@DeleteMapping("/collaborators/{id}")
+	@DeleteMapping("/collaborator/{id}")
 	public ResponseEntity<?> deleteCollaborator(@PathVariable("id") Long id){
 		collaboratorServ.deleteCollaborator(id);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body("Delete Collaborator with ID: " + id);

--- a/src/main/java/org/mongen/core/models/Collaborator.java
+++ b/src/main/java/org/mongen/core/models/Collaborator.java
@@ -29,6 +29,7 @@ public class Collaborator implements Serializable{
 	private String firstName;
 	@Column(name="last_name")
 	private String lastName;
+	private String email;
 	@Column(name="photo_id_url")
 	private String photoIdURL;
 	@JsonIgnore
@@ -49,16 +50,18 @@ public class Collaborator implements Serializable{
 		
 	}
 
-	public Collaborator(String first_name, String last_name, CollaboratorType type, Country country) {
+	public Collaborator(String first_name, String last_name, String email, CollaboratorType type, Country country) {
 		this.firstName = first_name;
 		this.lastName = last_name;
+		this.email = email;
 		this.type = type;
 		this.countryCollaborator = country;
 	}
 
-	public Collaborator(String first_name, String last_name, String photo_id_url, CollaboratorType type, Country country) {
+	public Collaborator(String first_name, String last_name, String email, String photo_id_url, CollaboratorType type, Country country) {
 		this.firstName = first_name;
 		this.lastName = last_name;
+		this.email = email;
 		this.photoIdURL = photo_id_url;
 		this.type = type;
 		this.countryCollaborator = country;

--- a/src/main/java/org/mongen/core/models/Organization.java
+++ b/src/main/java/org/mongen/core/models/Organization.java
@@ -22,6 +22,7 @@ public class Organization implements Serializable{
 	private String seoName;
 	private boolean verified;
 	private String address;
+	private String story;
 	private String mission;
 	private String vision;
 
@@ -60,9 +61,10 @@ public class Organization implements Serializable{
 		
 	}
 
-	public Organization(String name, String seo_name, String mission, String vision, String address, Country country, Collaborator contact) {
+	public Organization(String name, String seo_name, String story, String mission, String vision, String address, Country country, Collaborator contact) {
 		this.name = name;
 		this.seoName = seo_name;
+		this.story = story;
 		this.mission = mission;
 		this.vision = vision;
 		this.address = address;

--- a/src/main/java/org/mongen/core/models/payloads/CollaboratorPayload.java
+++ b/src/main/java/org/mongen/core/models/payloads/CollaboratorPayload.java
@@ -7,6 +7,7 @@ public class CollaboratorPayload{
 
 	private String first_name;
 	private String last_name;
+	private String email;
 	private String country_iso;
 	private String type;
 }

--- a/src/main/java/org/mongen/core/models/payloads/MainContactPayload.java
+++ b/src/main/java/org/mongen/core/models/payloads/MainContactPayload.java
@@ -4,9 +4,9 @@ import lombok.Data;
 
 @Data
 public class MainContactPayload {
-
 	private String first_name;
 	private String last_name;
+	private String email;
 	private String country_iso;
 	private String type;
 	private String photo_id_url;

--- a/src/main/java/org/mongen/core/models/payloads/OrganizationPayload.java
+++ b/src/main/java/org/mongen/core/models/payloads/OrganizationPayload.java
@@ -8,6 +8,7 @@ public class OrganizationPayload {
 	private String name;
 	private String seo_name;
 	private String address;
+	private String story;
 	private String mission;
 	private String vision;
 	private String country_iso;

--- a/src/main/java/org/mongen/core/models/responses/CollaboratorResponse.java
+++ b/src/main/java/org/mongen/core/models/responses/CollaboratorResponse.java
@@ -1,0 +1,30 @@
+package org.mongen.core.models.responses;
+
+import lombok.Data;
+import org.mongen.core.models.Collaborator;
+
+import java.util.Date;
+
+@Data
+public class CollaboratorResponse {
+
+	private Long id;
+	private String first_name;
+	private String last_name;
+	private String email;
+	private String user_type;
+	private Date created;
+	private Date updated;
+	private String nationality;
+
+	public CollaboratorResponse(Collaborator collaborator){
+		this.id = collaborator.getId();
+		this.first_name = collaborator.getFirstName();
+		this.last_name = collaborator.getLastName();
+		this.email = collaborator.getEmail();
+		this.user_type = collaborator.getType().getName();
+		this.nationality = collaborator.getCountryCollaborator().getName();
+		this.created = collaborator.getCreated();
+		this.updated = collaborator.getUpdated();
+	}
+}

--- a/src/main/java/org/mongen/core/models/responses/MainContactResponse.java
+++ b/src/main/java/org/mongen/core/models/responses/MainContactResponse.java
@@ -1,0 +1,32 @@
+package org.mongen.core.models.responses;
+
+import lombok.Data;
+import org.mongen.core.models.Collaborator;
+
+import java.util.Date;
+
+@Data
+public class MainContactResponse {
+
+	private Long id;
+	private String first_name;
+	private String last_name;
+	private String email;
+	private String user_type;
+	private String photo_id_url;
+	private Date created;
+	private Date updated;
+	private String nationality;
+
+	public MainContactResponse(Collaborator collaborator){
+		this.id = collaborator.getId();
+		this.first_name = collaborator.getFirstName();
+		this.last_name = collaborator.getLastName();
+		this.email = collaborator.getEmail();
+		this.user_type = collaborator.getType().getName();
+		this.photo_id_url = collaborator.getPhotoIdURL();
+		this.nationality = collaborator.getCountryCollaborator().getName();
+		this.created = collaborator.getCreated();
+		this.updated = collaborator.getUpdated();
+	}
+}

--- a/src/main/java/org/mongen/core/models/responses/OrganizationResponse.java
+++ b/src/main/java/org/mongen/core/models/responses/OrganizationResponse.java
@@ -13,9 +13,10 @@ public class OrganizationResponse {
 	private String name;
 	private String seo_name;
 	private String address;
+	private String story;
 	private String mission;
 	private String vision;
-	private Collaborator main_contact;
+	private MainContactResponse main_contact;
 	private boolean verified;
 	private Date created;
 	private Date updated;
@@ -26,9 +27,10 @@ public class OrganizationResponse {
 		this.name = org.getName();
 		this.seo_name = org.getSeoName();
 		this.address = org.getAddress();
+		this.story = org.getStory();
 		this.mission = org.getMission();
 		this.vision = org.getVision();
-		this.main_contact = org.getCollaborator();
+		this.main_contact = new MainContactResponse(org.getCollaborator()) ;
 		this.verified = org.isVerified();
 		this.created = org.getCreated();
 		this.updated = org.getUpdated();

--- a/src/main/java/org/mongen/core/service/CollaboratorService.java
+++ b/src/main/java/org/mongen/core/service/CollaboratorService.java
@@ -39,14 +39,14 @@ public class CollaboratorService {
 	public Collaborator createCollaborator(CollaboratorPayload collaborator_payload) {
 		Country country = countryRepo.findByCountryISO(collaborator_payload.getCountry_iso());
 		CollaboratorType type = collaboratorTypeRepo.findByName(collaborator_payload.getType());
-		Collaborator new_collaborator = new Collaborator(collaborator_payload.getFirst_name(), collaborator_payload.getLast_name(), type, country);
+		Collaborator new_collaborator = new Collaborator(collaborator_payload.getFirst_name(), collaborator_payload.getLast_name(), collaborator_payload.getEmail(), type, country);
 		return collaboratorRepo.save(new_collaborator);
 	}
 
 	public Collaborator createMainContact(MainContactPayload main_contact_payload) {
 		Country country = countryRepo.findByCountryISO(main_contact_payload.getCountry_iso());
 		CollaboratorType type = collaboratorTypeRepo.findByName(main_contact_payload.getType());
-		Collaborator new_collaborator = new Collaborator(main_contact_payload.getFirst_name(), main_contact_payload.getLast_name(), main_contact_payload.getPhoto_id_url(), type, country);
+		Collaborator new_collaborator = new Collaborator(main_contact_payload.getFirst_name(), main_contact_payload.getLast_name(), main_contact_payload.getEmail(), main_contact_payload.getPhoto_id_url(), type, country);
 		return collaboratorRepo.save(new_collaborator);
 	}
 	

--- a/src/main/java/org/mongen/core/service/OrganizationService.java
+++ b/src/main/java/org/mongen/core/service/OrganizationService.java
@@ -49,7 +49,7 @@ public class OrganizationService {
 	public Organization createOrganization(OrganizationPayload org_payload) {
 		Country country = countryRepo.findByCountryISO(org_payload.getCountry_iso());
 		Collaborator contact = collaboratorServ.findCollaboratorById(org_payload.getContact_id());
-		Organization new_org = new Organization(org_payload.getName(), org_payload.getSeo_name(), org_payload.getMission(), org_payload.getVision(), org_payload.getAddress(), country, contact);
+		Organization new_org = new Organization(org_payload.getName(), org_payload.getSeo_name(), org_payload.getStory(), org_payload.getMission(), org_payload.getVision(), org_payload.getAddress(), country, contact);
 		return organizationRepo.save(new_org);
 	}
 	


### PR DESCRIPTION
Saving `story` into Organization

Saving `email` into Collaborator

New response for collaborator and main contact endpoints:

```
{
  "created": "2021-02-06T08:01:52.746Z",
  "email": "string",
  "first_name": "string",
  "id": 0,
  "last_name": "string",
  "nationality": "string",
  "photo_id_url": "string",
  "updated": "2021-02-06T08:01:52.746Z",
  "user_type": "string"
}
```

The response for Collaborator is slightly different, the field `photo_id_url` is not returned.